### PR TITLE
Expose Table::new to pub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["html", "table", "parse"]
 categories = ["parsing"]
 
 [dependencies]
-scraper = "0.13"
+scraper = "0.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl Table {
         }
     }
 
-    fn new(element: ElementRef) -> Table {
+    pub fn new(element: ElementRef) -> Table {
         let sel_tr = css("tr");
         let sel_th = css("th");
         let sel_td = css("td");


### PR DESCRIPTION
Since I use `scraper` elsewhere in my code, it is more efficient to use it directly in `table-extract`, too. Hence, in this tiny PR I propose adding pub in front of `Table::new`. I've also updated `scraper` to the latest version.